### PR TITLE
get_lldp_neighbors: remove extra colon on port return value

### DIFF
--- a/napalm_aoscx/aoscx.py
+++ b/napalm_aoscx/aoscx.py
@@ -256,7 +256,7 @@ class AOSCXDriver(NetworkDriver):
             lldp_brief_return[interface_name].append(
                 {
                     'hostname': interface_details['neighbor_info']['chassis_name'],
-                    'port:': interface_details['port_id']
+                    'port': interface_details['port_id']
                 }
             )
 


### PR DESCRIPTION
Fix #7

Signed-off-by: Alexis La Goutte <alexis.lagoutte@gmail.com>