### PR TITLE
get_config: fix KeyError url

### DIFF
--- a/napalm_aoscx/aoscx.py
+++ b/napalm_aoscx/aoscx.py
@@ -608,9 +608,9 @@ class AOSCXDriver(NetworkDriver):
                 "candidate": ""
             }
             if retrieve in ["running", "all"]:
-                config_dict['running'] = self._get_json_configuration("running-config")
+                config_dict['running'] = self._get_json_configuration("running-config", **self.session_info)
             if retrieve in ["startup", "all"]:
-                config_dict['startup'] = self._get_json_configuration("startup-config")
+                config_dict['startup'] = self._get_json_configuration("startup-config", **self.session_info)
             if retrieve in ["candidate", "all"]:
                 config_dict['candidate'] = self.candidate_config
 


### PR DESCRIPTION
File "napalm-aruba-cx/napalm_aoscx/aoscx.py", line 625, in get_config
  config_dict['running'] = self._get_json_configuration("running-config")
File "napalm-aruba-cx/napalm_aoscx/aoscx.py", line 904, in _get_json_configuration
  target_url = kwargs["url"] + "fullconfigs/{}".format(checkpoint)
KeyError: 'url'

issue also reported on #5

Signed-off-by: Alexis La Goutte <alexis.lagoutte@gmail.com>