### PR TITLE
get_mac_address_table bug

### DIFF
--- a/napalm_aoscx/aoscx.py
+++ b/napalm_aoscx/aoscx.py
@@ -522,7 +522,7 @@ class AOSCXDriver(NetworkDriver):
             mac_entries.append(
                 {
                     'mac': mac,
-                    'interface': mac_info['port'][mac_info['port'].rfind('/')+1],
+                    'interface': mac_info['port'][mac_info['port'].rfind('/')+1:],
                     'vlan': vlan,
                     'static': (mac_type == 'static'),
                     'active': True,

--- a/napalm_aoscx/aoscx.py
+++ b/napalm_aoscx/aoscx.py
@@ -543,6 +543,7 @@ class AOSCXDriver(NetworkDriver):
                 * mode (string) # read-write (rw), read-only (ro) (Unsupported)
             * contact (string)
             * location (string)
+        Empty attributes are returned as an empty string (e.g. '') where applicable.
         """
         snmp_dict = {
             "chassis_id": "",
@@ -563,8 +564,9 @@ class AOSCXDriver(NetworkDriver):
 
         snmp_dict['chassis_id'] = productinfo['product_info']['serial_number']
         snmp_dict['community'] = communities_dict
-        snmp_dict['contact'] = systeminfo['other_config']['system_contact']
-        snmp_dict['location'] = systeminfo['other_config']['system_location']
+        if 'system_contact' and 'system_location' in systeminfo['other_config']:
+            snmp_dict['contact'] = systeminfo['other_config']['system_contact']
+            snmp_dict['location'] = systeminfo['other_config']['system_location']
 
         return snmp_dict
 

--- a/napalm_aoscx/aoscx.py
+++ b/napalm_aoscx/aoscx.py
@@ -564,8 +564,9 @@ class AOSCXDriver(NetworkDriver):
 
         snmp_dict['chassis_id'] = productinfo['product_info']['serial_number']
         snmp_dict['community'] = communities_dict
-        if 'system_contact' and 'system_location' in systeminfo['other_config']:
+        if 'system_contact' in systeminfo['other_config']:
             snmp_dict['contact'] = systeminfo['other_config']['system_contact']
+        if 'system_location' in systeminfo['other_config']:
             snmp_dict['location'] = systeminfo['other_config']['system_location']
 
         return snmp_dict


### PR DESCRIPTION
There was a bug that wasn't returning the complete interface name in the get_mac_address_table return value