### PR TITLE
Add use_cli optional argument to allow for CLI output format for get_config

### DIFF
--- a/napalm_aoscx/aoscx.py
+++ b/napalm_aoscx/aoscx.py
@@ -64,6 +64,8 @@ class AOSCXDriver(NetworkDriver):
         self.password = password
         self.timeout = timeout
         self.optional_args = optional_args
+        #Adding this due to the fact that optional args are not parsed from Nautobot to Napalm driver successfully
+        self.optional_args["use_cli"] = True
 
         self.platform = "aoscx"
         self.profile = [self.platform]

--- a/napalm_aoscx/aoscx.py
+++ b/napalm_aoscx/aoscx.py
@@ -71,7 +71,6 @@ class AOSCXDriver(NetworkDriver):
         self.isAlive = False
         self.candidate_config = ''
 
-
         self.base_url = "https://{0}/rest/v1/".format(self.hostname)
 
     def open(self):
@@ -117,6 +116,9 @@ class AOSCXDriver(NetworkDriver):
         """
         session.logout(**self.session_info)
         self.isAlive = False
+
+        if self.optional_args['use_cli']:
+            self.device.disconnect()
 
     def is_alive(self):
         """


### PR DESCRIPTION
Hello,

Sometimes it's desirable to have CLI style output for `get_config` - I want it to be able to use nautobot golden config to manage consistency checks and device remediation.

I couldn't find a way for the Aruba API to return the config in this format. So this change adds an optional argument `use_cli` to get the configs via a SSH session instead. By default the existing behaviour of reporting the JSON output is kept.

I felt this would be the simplest way to get the functionality I needed with minimal changes to current behaviour, but I'm open to suggestions for improvement,

Thanks!